### PR TITLE
Docs/Suggestion: Replace "layernorm" with "RMSNorm" for consistency

### DIFF
--- a/tests/adapters.py
+++ b/tests/adapters.py
@@ -287,7 +287,7 @@ def run_transformer_lm(
                 applied in the transformer block.
                 Shape is (d_model,).
             - `ln_final.weight`
-                Weights of affine transform for layernorm applied to the output of the final transformer block.
+                Weights of affine transform for RMSNorm applied to the output of the final transformer block.
                 Shape is (d_model, ).
             - `lm_head.weight`
                 Weights of the language model output embedding.

--- a/tests/adapters.py
+++ b/tests/adapters.py
@@ -314,7 +314,7 @@ def run_rmsnorm(
 
     Args:
         d_model: int
-            The dimensionality of the layernorm input.
+            The dimensionality of the RMSNorm input.
         eps: float, default is 1e-5
             A value added to the denominator for numerical stability.
         weights: dict[str, torch.FloatTensor]
@@ -329,7 +329,7 @@ def run_rmsnorm(
 
     Returns:
         FloatTensor of with the same shape as `in_features` with the output of running
-        layernorm of the `in_features`.
+        RMSNorm of the `in_features`.
     """
     raise NotImplementedError
 


### PR DESCRIPTION
For consistency, a small suggestion is to rename the docstring of `run_transformer_lm` in `tests/adapter.py` from "Weights of affine transform for layernorm ..." to "Weights of affine transform for RMSNorm ...". 